### PR TITLE
Fix package.json typos

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "inversion of control",
     "ioc",
     "ioc container",
-    "depedency",
-    "depedency injection",
+    "dependency",
+    "dependency injection",
     "injection"
   ],
   "author": {


### PR DESCRIPTION
Theory: Sack is suffering from low visibility due to people not being able to find it when searching for "dependency injection"
